### PR TITLE
Added support to decimal comma

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ function runCalculate ( editMaker : IEditMaker ){
 				}
 				
 				try{
-					var evaluatedMath = math.eval(selectedText.toString().replace(',','.'));
+					var evaluatedMath = math.eval(selectedText.toString().replace(/,/g,'.'));
 					editMaker(textEditorEdit,selection,evaluatedMath);
 				}catch (e){
 					erroralert.saveError("CALC_ERR",selectedText.toString());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ function runCalculate ( editMaker : IEditMaker ){
 				}
 				
 				try{
-					var evaluatedMath = math.eval(selectedText.toString());
+					var evaluatedMath = math.eval(selectedText.toString().replace(',','.'));
 					editMaker(textEditorEdit,selection,evaluatedMath);
 				}catch (e){
 					erroralert.saveError("CALC_ERR",selectedText.toString());


### PR DESCRIPTION
In Brazil and a lot of other countries. We use commas instead of dots how decimal separator.
For this reason, I put a simple replace that convert commas to dots.
This way both decimal separators are accepted to calculate.
Follow the link for reference: https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_Arabic_numerals_with_decimal_comma